### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@
 from fedora:latest
 RUN dnf install -y \
           arm-none-eabi-gcc\
-	  arm-none-eabi-newlib\
+          arm-none-eabi-newlib\
           findutils\
           gcc\
-	  git\
+          git\
           glib2-devel\
           libfdt-devel\
           pixman-devel\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Compile and install qemu_stm32
+from fedora:latest
+RUN dnf install -y \
+          arm-none-eabi-gcc\
+	  arm-none-eabi-newlib\
+          findutils\
+          gcc\
+	  git\
+          glib2-devel\
+          libfdt-devel\
+          pixman-devel\
+          pkgconf-pkg-config\
+          python\
+          zlib-devel ;\
+    git clone https://github.com/beckus/qemu_stm32.git
+RUN cd qemu_stm32 && ./configure --extra-cflags="-w" --enable-debug --target-list="arm-softmmu" && make && make install
+
+# Install demos
+RUN git clone https://github.com/beckus/stm32_p103_demos.git && cd stm32_p103_demos && make
+
+

--- a/README
+++ b/README
@@ -1,8 +1,8 @@
-# QEMU with STM32 Microcontroller Implementation
+QEMU with STM32 Microcontroller Implementation
 
 Official Homepage: http://beckus.github.io/qemu_stm32/
 
-## OVERVIEW
+OVERVIEW
 This is a copy of QEMU that has been modified to include an implementation
 of the STM32 microcontroller.  It also implements an Olimex STM32_P103
 developmentvboard.  This project runs the demos located in the
@@ -63,7 +63,7 @@ qemu-system-arm options which are useful for trobuleshooting:
         used for this to work.
         By default, you can find the output in /tmp/qemu.log:
 
-## UNIT TESTING
+UNIT TESTING
 Unit test scripts are included for the STM32 implementation.
 These test will be executed when running "make" with the standard
 check targets (see tests/Makefile for documentation of QEMU's unit
@@ -71,7 +71,7 @@ testing features):
     make check
     make check-qtest-arm
 
-## DOCKER CONTAINER
+DOCKER CONTAINER
 A Docker container containing qemu_stm32` can be built from `Dockerfile`:
 ```docker build . -t qemu_stm32```
 It can run the examples in `stm32_p103_demos`:

--- a/README
+++ b/README
@@ -1,8 +1,8 @@
-QEMU with STM32 Microcontroller Implementation
+# QEMU with STM32 Microcontroller Implementation
 
 Official Homepage: http://beckus.github.io/qemu_stm32/
 
-OVERVIEW
+## OVERVIEW
 This is a copy of QEMU that has been modified to include an implementation
 of the STM32 microcontroller.  It also implements an Olimex STM32_P103
 developmentvboard.  This project runs the demos located in the
@@ -63,7 +63,7 @@ qemu-system-arm options which are useful for trobuleshooting:
         used for this to work.
         By default, you can find the output in /tmp/qemu.log:
 
-UNIT TESTING
+## UNIT TESTING
 Unit test scripts are included for the STM32 implementation.
 These test will be executed when running "make" with the standard
 check targets (see tests/Makefile for documentation of QEMU's unit
@@ -71,6 +71,11 @@ testing features):
     make check
     make check-qtest-arm
 
+## DOCKER CONTAINER
+A Docker container containing qemu_stm32` can be built from `Dockerfile`:
+```docker build . -t qemu_stm32```
+It can run the examples in `stm32_p103_demos`:
+```docker run --rm qemu_stm32 /usr/local/bin/qemu-system-arm -M stm32-p103 -kernel /stm32_p103_demos/demos/freertos_singlethread/main.bin`
 
 
 The original QEMU README follows:

--- a/README
+++ b/README
@@ -72,10 +72,10 @@ testing features):
     make check-qtest-arm
 
 DOCKER CONTAINER
-A Docker container containing qemu_stm32` can be built from `Dockerfile`:
-```docker build . -t qemu_stm32```
-It can run the examples in `stm32_p103_demos`:
-```docker run --rm qemu_stm32 /usr/local/bin/qemu-system-arm -M stm32-p103 -kernel /stm32_p103_demos/demos/freertos_singlethread/main.bin`
+A Docker container containing qemu_stm32 can be built from the Dockerfile:
+    docker build . -t qemu_stm32
+It can run the examples in stm32_p103_demos:
+    docker run --rm qemu_stm32 /usr/local/bin/qemu-system-arm -M stm32-p103 -kernel /stm32_p103_demos/demos/freertos_singlethread/main.bin
 
 
 The original QEMU README follows:


### PR DESCRIPTION
Contains a Dockerfile to build a container with `qemu_stm32` binaries and examples from https://github.com/beckus/stm32_p103_demos.