### PR TITLE
Send stm32 debugging outputs to stderr, instead of stdout.

### DIFF
--- a/hw/arm/stm32_adc.c
+++ b/hw/arm/stm32_adc.c
@@ -31,7 +31,7 @@
 
 #ifdef DEBUG_STM32_ADC
 #define DPRINTF(fmt, ...)                                       \
-    do { printf("STM32_ADC: " fmt , ## __VA_ARGS__); } while (0)
+    do { fprintf(stderr, "STM32_ADC: " fmt , ## __VA_ARGS__); } while (0)
 #else
 #define DPRINTF(fmt, ...)
 #endif
@@ -912,7 +912,7 @@ static uint64_t stm32_adc_read(void *opaque, hwaddr offset,
 	case oADC_JDR4: return extract64(s->ADC_JDR4, start, length);
 	case oADC_DR  : return extract64(stm32_ADC_DR_read(s), start, length); 
         default:
-		printf("jmf unknown read : %lld, size %d\n",(long long)offset,size);
+		fprintf(stderr, "jmf unknown read : %lld, size %d\n",(long long)offset,size);
             STM32_BAD_REG(offset, size);
             return 0;
     }
@@ -942,7 +942,7 @@ static void stm32_adc_write(void *opaque, hwaddr offset,
 	case oADC_SQR3: (s->ADC_SQR3=value & 0x3fffffff);break;
 	case oADC_JSQR: (s->ADC_JSQR=value & 0x003fffff);break;
 	
-        default: printf("jmf unknown write : %lld, size %d\n",(long long)offset,size);
+        default: fprintf(stderr, "jmf unknown write : %lld, size %d\n",(long long)offset,size);
             STM32_BAD_REG(offset, 2);
             break;
     }

--- a/hw/arm/stm32_clktree.c
+++ b/hw/arm/stm32_clktree.c
@@ -77,7 +77,7 @@ static void clktree_print_state(Clk clk)
 {
     Clk input_clk = clktree_get_input_clk(clk);
 
-    printf("CLKTREE: %s Output Change (SrcClk:%s InFreq:%lu OutFreq:%lu Mul:%u Div:%u Enabled:%c)\n",
+    fprintf(stderr, "CLKTREE: %s Output Change (SrcClk:%s InFreq:%lu OutFreq:%lu Mul:%u Div:%u Enabled:%c)\n",
             clk->name,
             input_clk ? input_clk->name : "None",
             (unsigned long)clk->input_freq,

--- a/hw/arm/stm32_dac.c
+++ b/hw/arm/stm32_dac.c
@@ -30,7 +30,7 @@
 
 #ifdef DEBUG_STM32_DAC
 #define DPRINTF(fmt, ...)                                       \
-    do { printf("STM32_DAC: " fmt , ## __VA_ARGS__); } while (0)
+    do { fprintf(stderr, "STM32_DAC: " fmt , ## __VA_ARGS__); } while (0)
 #else
 #define DPRINTF(fmt, ...)
 #endif

--- a/hw/arm/stm32_dac.c
+++ b/hw/arm/stm32_dac.c
@@ -355,6 +355,11 @@ static void stm32_dac_conv_DACC1(void *opaque)
 {
    Stm32Dac *s=(Stm32Dac *)opaque;
    stm32_dac_check_pin(s,4);
+
+   // TODO: add a `-device dac` option to qemu which allows qemu's full range of I/O redirection options
+   //       just writing to a file *in the current directory* is a quick hack that's not production-ready.
+
+   // TODO: factor this with stm32_dav_conv_DACC2
    printf("DAC1output:%d\n",(s->Vref*(s->DAC_DOR1 & 0xfff))/4095);
    FILE* fichier=fopen("DAC_OUT_PUT1.txt", "a");
    fprintf(fichier, "%d\n",(s->Vref*(s->DAC_DOR1 & 0xfff))/4095);
@@ -368,6 +373,11 @@ static void stm32_dac_conv_DACC2(void *opaque)
 
    Stm32Dac *s=(Stm32Dac *)opaque;
    stm32_dac_check_pin(s,5);
+
+   // TODO: add a `-device dac` option to qemu which allows qemu's full range of I/O redirection options
+   //       just writing to a file *in the current directory* is a quick hack that's not production-ready.
+
+   // TODO: factor this with stm32_dav_conv_DACC1
    printf("DAC2output:%d\n",(s->Vref*(s->DAC_DOR2 & 0xfff))/4095);
    FILE* fichier=fopen("DAC_OUT_PUT2.txt", "a");
    fprintf(fichier, "%d\n",(s->Vref*(s->DAC_DOR2 & 0xfff))/4095);

--- a/hw/arm/stm32_rcc.c
+++ b/hw/arm/stm32_rcc.c
@@ -33,7 +33,7 @@
 
 #ifdef DEBUG_STM32_RCC
 #define DPRINTF(fmt, ...)                                       \
-    do { printf("STM32_RCC: " fmt , ## __VA_ARGS__); } while (0)
+    do { fprintf(stderr, "STM32_RCC: " fmt , ## __VA_ARGS__); } while (0)
 #else
 #define DPRINTF(fmt, ...)
 #endif

--- a/hw/char/stm32_uart.c
+++ b/hw/char/stm32_uart.c
@@ -36,7 +36,7 @@
 
 #ifdef DEBUG_STM32_UART
 #define DPRINTF(fmt, ...)                                       \
-    do { printf("STM32_UART: " fmt , ## __VA_ARGS__); } while (0)
+    do { fprintf(stderr, "STM32_UART: " fmt , ## __VA_ARGS__); } while (0)
 #else
 #define DPRINTF(fmt, ...)
 #endif

--- a/hw/timer/stm32_rtc.c
+++ b/hw/timer/stm32_rtc.c
@@ -35,7 +35,7 @@
 
 #ifdef DEBUG_STM32_RTC
 #define DPRINTF(fmt, ...)                                       \
-    do { printf("STM32_RTC: " fmt , ## __VA_ARGS__); } while (0)
+    do { fprintf(stderr, "STM32_RTC: " fmt , ## __VA_ARGS__); } while (0)
 #else
 #define DPRINTF(fmt, ...)
 #endif

--- a/hw/timer/stm32_timer.c
+++ b/hw/timer/stm32_timer.c
@@ -33,7 +33,7 @@
 
 #ifdef DEBUG_STM32_TIMER
 #define DPRINTF(fmt, ...)                                       \
-    do { printf("STM32_TIMER: " fmt , ## __VA_ARGS__); } while (0)
+    do { fprintf(stderr, "STM32_TIMER: " fmt , ## __VA_ARGS__); } while (0)
 #else
 #define DPRINTF(fmt, ...)
 #endif


### PR DESCRIPTION
They would get mixed into other output from `-serial stdio`
or `-monitor stdio` in a way that's hard to script around.