### PR TITLE
Allow building against new libgfapi.so API

### DIFF
--- a/block/gluster.c
+++ b/block/gluster.c
@@ -11,6 +11,10 @@
 #include "block/block_int.h"
 #include "qemu/uri.h"
 
+#ifdef CONFIG_GLUSTERFS_FTRUNCATE_HAS_STAT
+# define glfs_ftruncate(fd, offset) glfs_ftruncate(fd, offset, NULL, NULL)
+#endif
+
 typedef struct GlusterAIOCB {
     int64_t size;
     int ret;

--- a/block/gluster.c
+++ b/block/gluster.c
@@ -242,7 +242,11 @@ static void qemu_gluster_complete_aio(void *opaque)
 /*
  * AIO callback routine called from GlusterFS thread.
  */
-static void gluster_finish_aiocb(struct glfs_fd *fd, ssize_t ret, void *arg)
+static void gluster_finish_aiocb(struct glfs_fd *fd, ssize_t ret,
+#ifdef CONFIG_GLUSTERFS_IOCB_HAS_STAT
+                                 struct glfs_stat *pre, struct glfs_stat *post,
+#endif
+                                 void *arg)
 {
     GlusterAIOCB *acb = (GlusterAIOCB *)arg;
 

--- a/configure
+++ b/configure
@@ -327,6 +327,7 @@ glusterfs=""
 glusterfs_discard="no"
 glusterfs_zerofill="no"
 glusterfs_ftruncate_has_stat="no"
+glusterfs_iocb_has_stat="no"
 virtio_blk_data_plane=""
 gtk=""
 gtkabi=""
@@ -3099,6 +3100,25 @@ EOF
     if compile_prog "$glusterfs_cflags" "$glusterfs_libs" ; then
       glusterfs_ftruncate_has_stat="yes"
     fi
+    cat > $TMPC << EOF
+#include <glusterfs/api/glfs.h>
+
+/* new glfs_io_cbk() passes two additional glfs_stat structs */
+static void
+glusterfs_iocb(glfs_fd_t *fd, ssize_t ret, struct glfs_stat *prestat, struct glfs_stat *poststat, void *data)
+{}
+
+int
+main(void)
+{
+       glfs_io_cbk iocb = &glusterfs_iocb;
+       iocb(NULL, 0 , NULL, NULL, NULL);
+       return 0;
+}
+EOF
+    if compile_prog "$glusterfs_cflags" "$glusterfs_libs" ; then
+      glusterfs_iocb_has_stat="yes"
+    fi
   else
     if test "$glusterfs" = "yes" ; then
       feature_not_found "GlusterFS backend support" "Install glusterfs-api devel"
@@ -4705,6 +4725,10 @@ fi
 
 if test "$glusterfs_ftruncate_has_stat" = "yes" ; then
   echo "CONFIG_GLUSTERFS_FTRUNCATE_HAS_STAT=y" >> $config_host_mak
+fi
+
+if test "$glusterfs_iocb_has_stat" = "yes" ; then
+  echo "CONFIG_GLUSTERFS_IOCB_HAS_STAT=y" >> $config_host_mak
 fi
 
 if test "$libssh2" = "yes" ; then

--- a/configure
+++ b/configure
@@ -326,6 +326,7 @@ seccomp=""
 glusterfs=""
 glusterfs_discard="no"
 glusterfs_zerofill="no"
+glusterfs_ftruncate_has_stat="no"
 virtio_blk_data_plane=""
 gtk=""
 gtkabi=""
@@ -3085,6 +3086,19 @@ if test "$glusterfs" != "no" ; then
     if $pkg_config --atleast-version=6 glusterfs-api; then
       glusterfs_zerofill="yes"
     fi
+    cat > $TMPC << EOF
+#include <glusterfs/api/glfs.h>
+
+int
+main(void)
+{
+       /* new glfs_ftruncate() passes two additional args */
+       return glfs_ftruncate(NULL, 0, NULL, NULL);
+}
+EOF
+    if compile_prog "$glusterfs_cflags" "$glusterfs_libs" ; then
+      glusterfs_ftruncate_has_stat="yes"
+    fi
   else
     if test "$glusterfs" = "yes" ; then
       feature_not_found "GlusterFS backend support" "Install glusterfs-api devel"
@@ -4687,6 +4701,10 @@ fi
 
 if test "$glusterfs_zerofill" = "yes" ; then
   echo "CONFIG_GLUSTERFS_ZEROFILL=y" >> $config_host_mak
+fi
+
+if test "$glusterfs_ftruncate_has_stat" = "yes" ; then
+  echo "CONFIG_GLUSTERFS_FTRUNCATE_HAS_STAT=y" >> $config_host_mak
 fi
 
 if test "$libssh2" = "yes" ; then


### PR DESCRIPTION
Changes in new versions of Glusters libgfapi.so mean that this fork doesn't build on an up-to-date system.

This PR implements functionality of commits e014dbe and 0e3b891 from mainline to make it build again.