### PR TITLE
ported the flash peripheral from pebble/qemu and added support to reset

### DIFF
--- a/hw/arm/Makefile.objs
+++ b/hw/arm/Makefile.objs
@@ -9,4 +9,5 @@ obj-$(CONFIG_DIGIC) += digic.o
 obj-y += omap1.o omap2.o strongarm.o
 obj-$(CONFIG_ALLWINNER_A10) += allwinner-a10.o cubieboard.o
 
-obj-y += stm32.o stm32_rcc.o stm32_clktree.o stm32_p103.o stm32_maple.o stm32_adc.o stm32_dac.o stm32_iwdg.o stm32_f103c8.o stm32_crc.o stm32_dma.o
+obj-y += stm32.o stm32_rcc.o stm32_clktree.o stm32_p103.o stm32_maple.o stm32_adc.o \
+	stm32_dac.o stm32_iwdg.o stm32_f103c8.o stm32_crc.o stm32_dma.o stm32_flash.o

--- a/hw/arm/stm32.c
+++ b/hw/arm/stm32.c
@@ -277,7 +277,7 @@ void stm32_init(
                  address_space_mem,
                  0,
                  flash_size);
-         memory_region_add_subregion(address_space_mem, 0x08000000, flash_alias_mem);
+         memory_region_add_subregion(address_space_mem, STM32_FLASH_ADDR_START, flash_alias_mem);
     }
     else{ //Use new FLASH mode with reset support
          dinfo = drive_get(IF_PFLASH, 0, 0);

--- a/hw/arm/stm32.c
+++ b/hw/arm/stm32.c
@@ -22,6 +22,7 @@
 #include "hw/arm/stm32.h"
 #include "exec/address-spaces.h"
 #include "exec/gdbstub.h"
+#include "sysemu/blockdev.h" // drive_get
 
 /* DEFINITIONS */
 
@@ -225,6 +226,12 @@ static void stm32_create_dac_dev(
     
 }
 
+static uint64_t kernel_load_translate_fn(void *opaque, uint64_t from_addr) {
+    if (from_addr == STM32_FLASH_ADDR_START) {
+        return 0x00000000;
+    }
+    return from_addr;
+}
 
 void stm32_init(
             ram_addr_t flash_size,
@@ -234,39 +241,61 @@ void stm32_init(
             uint32_t osc32_freq)
 {
     MemoryRegion *address_space_mem = get_system_memory();
-    MemoryRegion *flash_alias_mem = g_malloc(sizeof(MemoryRegion));
     qemu_irq *pic;
+    DriveInfo *dinfo;
     int i;
 
     Object *stm32_container = container_get(qdev_get_machine(), "/stm32");
 
-    pic = armv7m_init(
+    pic = armv7m_translated_init(
               stm32_container,
               address_space_mem,
               flash_size,
               ram_size,
               kernel_filename,
+              kernel_load_translate_fn,
+              NULL,
               "cortex-m3");
-
-    /* The STM32 family stores its Flash memory at some base address in memory
-     * (0x08000000 for medium density devices), and then aliases it to the
-     * boot memory space, which starts at 0x00000000 (the "System Memory" can also
-     * be aliased to 0x00000000, but this is not implemented here). The processor
-     * executes the code in the aliased memory at 0x00000000.  We need to make a
-     * QEMU alias so that reads in the 0x08000000 area are passed through to the
-     * 0x00000000 area. Note that this is the opposite of real hardware, where the
-     * memory at 0x00000000 passes reads through the "real" flash memory at
-     * 0x08000000, but it works the same either way. */
-    /* TODO: Parameterize the base address of the aliased memory. */
-    memory_region_init_alias(
-            flash_alias_mem,
-            NULL,
-            "stm32-flash-alias-mem",
-            address_space_mem,
-            0,
-            flash_size);
-    memory_region_add_subregion(address_space_mem, 0x08000000, flash_alias_mem);
-
+    
+    if(kernel_filename) //Use legacy mode without reset support
+    {
+          MemoryRegion *flash_alias_mem = g_malloc(sizeof(MemoryRegion));
+          /* The STM32 family stores its Flash memory at some base address in memory
+          * (0x08000000 for medium density devices), and then aliases it to the
+          * boot memory space, which starts at 0x00000000 (the "System Memory" can also
+          * be aliased to 0x00000000, but this is not implemented here). The processor
+          * executes the code in the aliased memory at 0x00000000.  We need to make a
+          * QEMU alias so that reads in the 0x08000000 area are passed through to the
+          * 0x00000000 area. Note that this is the opposite of real hardware, where the
+          * memory at 0x00000000 passes reads through the "real" flash memory at
+          * 0x08000000, but it works the same either way. */
+         /* TODO: Parameterize the base address of the aliased memory. */
+         memory_region_init_alias(
+                 flash_alias_mem,
+                 NULL,
+                 "stm32-flash-alias-mem",
+                 address_space_mem,
+                 0,
+                 flash_size);
+         memory_region_add_subregion(address_space_mem, 0x08000000, flash_alias_mem);
+    }
+    else{ //Use new FLASH mode with reset support
+         dinfo = drive_get(IF_PFLASH, 0, 0);
+         if (dinfo) {
+             stm32_flash_register(dinfo->bdrv , STM32_FLASH_ADDR_START, flash_size);
+         }
+         MemoryRegionSection mrs = memory_region_find(address_space_mem, STM32_FLASH_ADDR_START, 4 /*WORD_ACCESS_SIZE*/);
+         MemoryRegion *flash_alias_mem = g_new(MemoryRegion, 1);
+         memory_region_init_alias(
+               flash_alias_mem,
+               NULL,
+               "stm32-flash-alias-mem",
+               mrs.mr, 
+               0,
+               flash_size);
+         memory_region_add_subregion(address_space_mem, 0, flash_alias_mem);
+    }
+    
     DeviceState *rcc_dev = qdev_create(NULL, "stm32-rcc");
     qdev_prop_set_uint32(rcc_dev, "osc_freq", osc_freq);
     qdev_prop_set_uint32(rcc_dev, "osc32_freq", osc32_freq);
@@ -337,10 +366,14 @@ void stm32_init(
     qdev_prop_set_ptr(iwdg_dev, "stm32_rcc", rcc_dev);
     stm32_init_periph(iwdg_dev, STM32_IWDG, 0x40003000, NULL);
 
-	/* CRC */
-	DeviceState *crc = qdev_create(NULL, "stm32-crc");
-	stm32_init_periph(crc, STM32_CRC, 0x40023000, NULL);
-
+    /* CRC */
+    DeviceState *crc = qdev_create(NULL, "stm32-crc");
+    stm32_init_periph(crc, STM32_CRC, 0x40023000, NULL);
+    
+    /* FLASH regs */
+    DeviceState *flash_regs = qdev_create(NULL, "stm32-flash-regs");
+    stm32_init_periph(flash_regs, STM32_FLASH_REGS, 0x40022000, NULL);
+    
     DeviceState *dma1 = qdev_create(NULL, "stm32_dma");
     stm32_init_periph(dma1, STM32_DMA1, 0x40020000, NULL);
     sysbus_connect_irq(SYS_BUS_DEVICE(dma1), 0, pic[STM32_DMA1_STREAM0_IRQ]);

--- a/hw/arm/stm32_flash.c
+++ b/hw/arm/stm32_flash.c
@@ -1,0 +1,443 @@
+/*
+ * STM32 Microcontroller Flash Memory
+ * The STM32 family stores its Flash memory at some base address in memory
+ * (0x08000000 for medium density devices), and then aliases it to the
+ * boot memory space, which starts at 0x00000000 (the System Memory can also
+ * be aliased to 0x00000000, but this is not implemented here).  The processor
+ * executes the code in the aliased memory at 0x00000000, but we need to
+ * implement the "real" flash memory as well.  This "real" flash memory will
+ * pass reads through to the memory at 0x00000000, which is where QEMU loads
+ * the executable image.  Note that this is opposite of real hardware, where the
+ * memory at 0x00000000 passes reads through the "real" flash memory, but it
+ * works the same either way.
+ *
+ * Copyright (C) 2010 Andre Beckus
+ *
+ * Implementation based on ST Microelectronics "RM0008 Reference Manual Rev 10"
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "hw/arm/stm32.h"
+
+#include "sysemu/blockdev.h"
+#include "hw/hw.h"
+#include "hw/block/flash.h"
+#include "block/block.h"
+#include "hw/sysbus.h"
+
+
+static uint32_t is_flash_locked = 1;
+static uint32_t flash_programming_bit = 0;
+
+
+typedef struct Stm32Flash {
+	SysBusDevice busdev;   
+    BlockDriverState * blks;
+    hwaddr base_address;
+	uint32_t size;
+    MemoryRegion iomem;
+    void *data;
+    hwaddr SP_init;
+    hwaddr PC_init;    
+} Stm32Flash;
+
+
+/* */
+Stm32Flash *stm32_flash_register(BlockDriverState *blks, hwaddr base,
+                                  hwaddr size)
+{
+    DeviceState *dev = qdev_create(NULL, "stm32-flash");
+    Stm32Flash *flash = (Stm32Flash *)object_dynamic_cast(OBJECT(dev),"stm32-flash");
+    qdev_prop_set_uint32(dev, "size", size);
+    qdev_prop_set_uint64(dev, "base_address", base);
+    if (blks) {
+    	int err = 0;
+        err = qdev_prop_set_drive(dev, "drive", blks);
+        if (err) {
+            printf("%s, have no drive???\n", __func__);
+            return NULL;
+        }
+    }
+    qdev_init_nofail(dev);   
+    //sysbus_mmio_map(SYS_BUS_DEVICE(dev), 0, base);
+  
+    return flash;
+}
+
+
+MemoryRegion *get_system_memory(void); /* XXX */
+
+static int stm32_flash_init(SysBusDevice *dev)
+{    
+    Stm32Flash*flash = DO_UPCAST(Stm32Flash, busdev, dev);
+
+//    memory_region_init_rom_device(&flash->mem, &f2xx_flash_ops, flash, "name",
+//      size);
+    memory_region_init_ram(&flash->iomem, NULL, "f2xx.flash", flash->size);
+
+    vmstate_register_ram(&flash->iomem, DEVICE(flash));
+    //vmstate_register_ram_global(&flash->iomem);
+    memory_region_set_readonly(&flash->iomem, true);
+    memory_region_add_subregion(get_system_memory(), flash->base_address, &flash->iomem);
+//    sysbus_init_mmio(dev, &flash->mem);
+
+    flash->data = memory_region_get_ram_ptr(&flash->iomem);
+    memset(flash->data, 0xff, flash->size);
+    if (flash->blks) {
+        int r;
+        r = bdrv_read(flash->blks, 0, flash->data, bdrv_getlength(flash->blks)/BDRV_SECTOR_SIZE);
+        if (r < 0) {
+            vmstate_unregister_ram(&flash->iomem, DEVICE(flash));
+            // memory_region_destroy(&flash->mem);
+            return 1;
+        }
+        else{
+          uint32_t * mem = flash->data; 
+          flash->PC_init = mem[1]; 
+          flash->SP_init = mem[0];   
+        }
+    }
+
+    return 0;
+}
+
+static void
+stm32_flash_reset(DeviceState *ds)
+{
+	Stm32Flash *s = STM32_FLASH(ds);
+
+	printf("reset is called!\n\n");
+   
+    //ARM M3 FLASH reset
+    ARMCPU *cpu = ARM_CPU(qemu_get_cpu(0));
+    CPUARMState *env = &cpu->env; 
+   
+    env->regs[13] = s->SP_init & 0xFFFFFFFC;
+    env->thumb = s->PC_init & 1;
+    env->regs[15] = s->PC_init & ~1;
+    
+}
+
+static Property stm32_flash_properties[] = {
+    DEFINE_PROP_DRIVE("drive", Stm32Flash, blks),
+    DEFINE_PROP_UINT32("size", Stm32Flash, size, 0),
+    DEFINE_PROP_UINT64("base_address", Stm32Flash , base_address, 0x08000000),
+    DEFINE_PROP_END_OF_LIST(),
+};
+
+
+static void stm32_flash_class_init(ObjectClass *klass, void *data)
+{
+	DeviceClass *dc = DEVICE_CLASS(klass);
+	SysBusDeviceClass *k = SYS_BUS_DEVICE_CLASS(klass);
+
+	k->init = stm32_flash_init;
+	dc->props = stm32_flash_properties;
+    dc->reset = stm32_flash_reset;
+}
+
+static TypeInfo stm32_flash_info = {
+	.name          = "stm32-flash",
+	.parent        = TYPE_SYS_BUS_DEVICE,
+	.instance_size = sizeof(Stm32Flash),
+	.class_init    = stm32_flash_class_init,
+};
+
+
+static void stm32_flash_register_types(void)
+{
+	type_register_static(&stm32_flash_info);
+}
+
+type_init(stm32_flash_register_types);
+
+
+//////regs
+
+
+#define R_FLASH_ACR            (0x00 / 4)
+#define R_FLASH_KEYR           (0x04 / 4)
+#define R_FLASH_OPTKEYR        (0x08 / 4)
+#define R_FLASH_SR             (0x0c / 4)
+#define R_FLASH_CR             (0x10 / 4)
+#define R_FLASH_AR             (0x14 / 4)
+#define R_FLASH_RESERVED       (0x18 / 4)
+#define R_FLASH_OBR            (0x1c / 4)
+#define R_FLASH_WRPR           (0x20 / 4)
+#define R_FLASH_MAX            (0x24 / 4)
+
+
+
+
+///
+#define FLASH_CR_PG_Pos                     (0U)                               
+#define FLASH_CR_PG_Msk                     (0x1U << FLASH_CR_PG_Pos)          /*!< 0x00000001 */
+#define FLASH_CR_PG                         FLASH_CR_PG_Msk                    /*!< Programming */
+#define FLASH_CR_PER_Pos                    (1U)                               
+#define FLASH_CR_PER_Msk                    (0x1U << FLASH_CR_PER_Pos)         /*!< 0x00000002 */
+#define FLASH_CR_PER                        FLASH_CR_PER_Msk                   /*!< Page Erase */
+#define FLASH_CR_MER_Pos                    (2U)                               
+#define FLASH_CR_MER_Msk                    (0x1U << FLASH_CR_MER_Pos)         /*!< 0x00000004 */
+#define FLASH_CR_MER                        FLASH_CR_MER_Msk                   /*!< Mass Erase */
+#define FLASH_CR_OPTPG_Pos                  (4U)                               
+#define FLASH_CR_OPTPG_Msk                  (0x1U << FLASH_CR_OPTPG_Pos)       /*!< 0x00000010 */
+#define FLASH_CR_OPTPG                      FLASH_CR_OPTPG_Msk                 /*!< Option Byte Programming */
+#define FLASH_CR_OPTER_Pos                  (5U)                               
+#define FLASH_CR_OPTER_Msk                  (0x1U << FLASH_CR_OPTER_Pos)       /*!< 0x00000020 */
+#define FLASH_CR_OPTER                      FLASH_CR_OPTER_Msk                 /*!< Option Byte Erase */
+#define FLASH_CR_STRT_Pos                   (6U)                               
+#define FLASH_CR_STRT_Msk                   (0x1U << FLASH_CR_STRT_Pos)        /*!< 0x00000040 */
+#define FLASH_CR_STRT                       FLASH_CR_STRT_Msk                  /*!< Start */
+#define FLASH_CR_LOCK_Pos                   (7U)                               
+#define FLASH_CR_LOCK_Msk                   (0x1U << FLASH_CR_LOCK_Pos)        /*!< 0x00000080 */
+#define FLASH_CR_LOCK                       FLASH_CR_LOCK_Msk                  /*!< Lock */
+#define FLASH_CR_OPTWRE_Pos                 (9U)                               
+#define FLASH_CR_OPTWRE_Msk                 (0x1U << FLASH_CR_OPTWRE_Pos)      /*!< 0x00000200 */
+#define FLASH_CR_OPTWRE                     FLASH_CR_OPTWRE_Msk                /*!< Option Bytes Write Enable */
+#define FLASH_CR_ERRIE_Pos                  (10U)                              
+#define FLASH_CR_ERRIE_Msk                  (0x1U << FLASH_CR_ERRIE_Pos)       /*!< 0x00000400 */
+#define FLASH_CR_ERRIE                      FLASH_CR_ERRIE_Msk                 /*!< Error Interrupt Enable */
+#define FLASH_CR_EOPIE_Pos                  (12U)                              
+#define FLASH_CR_EOPIE_Msk                  (0x1U << FLASH_CR_EOPIE_Pos)       /*!< 0x00001000 */
+#define FLASH_CR_EOPIE                      FLASH_CR_EOPIE_Msk                 /*!< End of operation interrupt enable */
+
+
+
+#define FLASH_KEY1                          0x45670123U                     /*!< FPEC Key1 */
+#define FLASH_KEY2                          0xCDEF89ABU                     /*!< FPEC Key2 */
+
+#define  FLASH_OPTKEY1                       FLASH_KEY1                    /*!< Option Byte Key1 */
+#define  FLASH_OPTKEY2                       FLASH_KEY2                    /*!< Option Byte Key2 */
+
+///
+
+typedef struct Stm32FlashRegs {
+	SysBusDevice busdev;
+	MemoryRegion iomem;
+
+	uint32_t ACR;
+	uint32_t KEYR;
+	uint32_t OPTKEYR;
+	uint32_t SR;
+	uint32_t CR;
+	uint32_t AR;
+	uint32_t RESERVED;
+	uint32_t OBR;
+	uint32_t WRPR;
+} Stm32FlashRegs;
+
+static uint64_t
+stm32_flash_regs_read(void *arg, hwaddr addr, unsigned int size)
+{
+	Stm32FlashRegs *s = arg;
+
+	if (size != 4) {
+		qemu_log_mask(LOG_UNIMP, "stm32 flash only supports 4-byte reads\n");
+		return 0;
+	}
+
+	addr >>= 2;
+	if (addr >= R_FLASH_MAX) {
+		qemu_log_mask(LOG_GUEST_ERROR, "invalid read stm32 flash register 0x%x\n",
+		  (unsigned int)addr << 2);
+		return 0;
+	}
+
+	switch(addr) {
+	case R_FLASH_ACR:
+		return s->ACR;
+	case R_FLASH_KEYR:
+		return s->KEYR;
+	case R_FLASH_OPTKEYR:
+		return s->OPTKEYR;
+	case R_FLASH_SR:
+		return s->SR;
+	case R_FLASH_CR:
+		return s->CR;
+	case R_FLASH_AR:
+		return s->AR;
+	case R_FLASH_RESERVED:
+		return s->RESERVED;
+	case R_FLASH_OBR:
+		return s->OBR;
+	case R_FLASH_WRPR:
+		return s->WRPR;
+	}
+	return 0;
+}
+
+
+static void
+stm32_flash_regs_write(void *arg, hwaddr addr, uint64_t data, unsigned int size)
+{
+	Stm32FlashRegs *s = arg;
+
+	/* XXX Check periph clock enable. */
+	if (size != 4) {
+		qemu_log_mask(LOG_UNIMP, "stm32 flash only supports 4-byte writes\n");
+		return;
+	}
+
+	addr >>= 2;
+	if (addr >= R_FLASH_MAX) {
+		qemu_log_mask(LOG_GUEST_ERROR, "invalid write stm32 flash register 0x%x\n",
+		  (unsigned int)addr << 2);
+		return;
+	}
+	switch(addr) {
+	case R_FLASH_ACR:
+		s->ACR = data;
+		break;
+
+	case R_FLASH_KEYR:
+		if (s->KEYR == FLASH_OPTKEY1 && data == FLASH_OPTKEY2) {
+			printf("Flash is unlocked!\n");
+			s->CR &= ~FLASH_CR_LOCK;
+			is_flash_locked = 0;
+		}
+		s->KEYR = data;
+		break;
+
+	case R_FLASH_OPTKEYR:
+		s->OPTKEYR = data;
+		break;
+
+	case R_FLASH_SR:
+		s->SR = data;
+		break;
+
+	case R_FLASH_CR:
+		if (is_flash_locked == 0 && (data & FLASH_CR_LOCK)) {
+			if (data & FLASH_CR_PG)
+				hw_error("stm32_flash: Attempted to write flash lock while flash program is on!");
+			printf("Flash is locked!\n");
+			//s->CR &= ~FLASH_CR_LOCK;
+			is_flash_locked = 1;
+
+		} else if ( (s->CR & FLASH_CR_PER) && (data & FLASH_CR_STRT) ) { //erase
+			if (data & FLASH_CR_PG || (data & FLASH_CR_LOCK))
+				hw_error("stm32_flash: Attempted to erase flash block while flash program/flash lock is on!");
+
+			printf("start erase\n");
+			/*
+            if ( (s->AR % 1024) == 0 && (s->AR >= 0x10000000) && (s->AR <= 0x10010000) ) {
+
+				fseek(fp, (s->AR) - 0x10000000, SEEK_SET);
+				if (fwrite( two_block_zeros , 1, 1024, fp) != 1024)
+					printf("warning: error erase!\n");
+			} else {
+				printf("ADDRESS: %u\n", s->AR);
+				hw_error("stm32_flash: Attempted to erase flash memory page while address is not alligned!");
+			}
+            */
+		} else if (data & FLASH_CR_PG) {
+			if (data & FLASH_CR_LOCK || data & FLASH_CR_PER)
+				hw_error("stm32_flash: Attempted to write flash program while flash lock/flash erase is on!");
+			flash_programming_bit = 1;
+
+		} else if (data & ~FLASH_CR_PG) {
+			flash_programming_bit = 0;
+		}
+
+		s->CR = data;
+		break;
+
+	case R_FLASH_AR:
+		s->AR = data;
+		break;
+
+	case R_FLASH_RESERVED:
+		s->RESERVED = data;
+		break;
+
+	case R_FLASH_OBR:
+		s->OBR = data;
+		break;
+
+	case R_FLASH_WRPR:
+		s->WRPR = data;
+		break;
+
+	}
+
+	return;
+}
+
+static const MemoryRegionOps stm32_flash_regs_ops = {
+	.read = stm32_flash_regs_read,
+	.write = stm32_flash_regs_write,
+	.endianness = DEVICE_NATIVE_ENDIAN,
+	.impl = {
+		.min_access_size = 1,
+		.max_access_size = 4,
+	}
+};
+
+static int
+stm32_flash_regs_init(SysBusDevice *dev)
+{
+	Stm32FlashRegs *s = STM32_FLASH_REGS(dev);
+
+	memory_region_init_io(&s->iomem, OBJECT(s), &stm32_flash_regs_ops, s, "flash-regs", 0x400);
+	sysbus_init_mmio(dev, &s->iomem);
+
+	return 0;
+}
+
+static void
+stm32_flash_regs_reset(DeviceState *ds)
+{
+	Stm32FlashRegs *s = STM32_FLASH_REGS(ds);
+
+	s->ACR = 0;
+	s->KEYR = 0;
+	s->OPTKEYR = 0;
+	s->SR = 0;
+	s->CR = 0;
+	s->AR = 0;
+	s->RESERVED = 0;
+	s->OBR = 0;
+	s->WRPR = 0;
+
+	is_flash_locked = 1;
+}
+
+
+static void
+stm32_flash_regs_class_init(ObjectClass *klass, void *data)
+{
+	DeviceClass *dc = DEVICE_CLASS(klass);
+	SysBusDeviceClass *sc = SYS_BUS_DEVICE_CLASS(klass);
+	sc->init = stm32_flash_regs_init;
+	dc->reset = stm32_flash_regs_reset;
+}
+
+static const TypeInfo
+stm32_crc_info = {
+	.name          = "stm32-flash-regs",
+	.parent        = TYPE_SYS_BUS_DEVICE,
+	.instance_size = sizeof(Stm32FlashRegs),
+	.class_init    = stm32_flash_regs_class_init,
+};
+
+static void
+stm32_crc_register_types(void)
+{
+	type_register_static(&stm32_crc_info);
+}
+
+type_init(stm32_crc_register_types);
+
+

--- a/include/hw/arm/arm.h
+++ b/include/hw/arm/arm.h
@@ -19,6 +19,13 @@ qemu_irq *armv7m_init(Object *parent, MemoryRegion *address_space_mem,
                       int flash_size, int sram_size,
                       const char *kernel_filename, const char *cpu_model);
 
+qemu_irq *armv7m_translated_init(Object *parent, MemoryRegion *address_space_mem,
+                      int flash_size, int sram_size,
+                      const char *kernel_filename, 
+		      uint64_t (*translate_fn)(void *, uint64_t),
+		      void *translate_opaque, 
+		      const char *cpu_model);
+
 /* arm_boot.c */
 struct arm_boot_info {
     uint64_t ram_size;

--- a/include/hw/arm/stm32.h
+++ b/include/hw/arm/stm32.h
@@ -32,6 +32,7 @@
 void stm32_hw_warn(const char *fmt, ...)
     __attribute__ ((__format__ (__printf__, 1, 2)));
 
+#define STM32_FLASH_ADDR_START (0x08000000)
 
 #define ENUM_STRING(x) [x] = #x
 #define ARRAY_LENGTH(array) (sizeof((array))/sizeof((array)[0]))
@@ -133,6 +134,8 @@ enum {
     STM32_HASH_PERIPH,
     STM32_RNG_PERIPH,
     STM32_PERIPH_COUNT,
+    STM32_FLASH,
+    STM32_FLASH_REGS,
 };
 
 const char *stm32_periph_name(stm32_periph_t periph);
@@ -383,6 +386,22 @@ typedef struct Stm32crc Stm32crc;
 
 #define TYPE_STM32_CRC "stm32-crc"
 #define STM32_CRC(obj) OBJECT_CHECK(Stm32crc, (obj), TYPE_STM32_CRC)
+
+/* FLASH */
+typedef struct Stm32Flash Stm32Flash;
+
+#define TYPE_STM32_FLASH "stm32-flash"
+#define STM32_FLASH(obj) OBJECT_CHECK(Stm32Flash, (obj), TYPE_STM32_FLASH)
+
+Stm32Flash *stm32_flash_register(BlockDriverState *blks, hwaddr base, hwaddr size);
+
+
+/* Flash Regs */
+typedef struct Stm32FlashRegs Stm32FlashRegs;
+
+#define TYPE_STM32_FLASH_REGS "stm32-flash-regs"
+#define STM32_FLASH_REGS(obj) OBJECT_CHECK(Stm32FlashRegs, (obj), TYPE_STM32_FLASH_REGS)
+
 
 /* DMA1 */
 typedef struct stm32_dma stm32_dma;


### PR DESCRIPTION
I adapted Pebble's support to load the file from a flash drive. The -pflash file.bin option should now be used instead of -kernel (which still works). The flash reset function loads the address of the stack and the pc that is specific to the ARM M3, allowing the qemu to be reset.
Support for FLASH_REGS was copied from the https://github.com/baselsayeh/qemu_stm32_flash repository and added so that binaries compiled on Arduino run without generating problem. The programs write and check the flash latency value.