### PR TITLE
Fix Dockerfile does not work with fedora:latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Compile and install qemu_stm32
-from fedora:latest
+from fedora:28
 RUN dnf install -y \
           arm-none-eabi-gcc\
           arm-none-eabi-newlib\
@@ -11,11 +11,10 @@ RUN dnf install -y \
           pixman-devel\
           pkgconf-pkg-config\
           python\
+          make\
           zlib-devel ;\
     git clone https://github.com/beckus/qemu_stm32.git
 RUN cd qemu_stm32 && ./configure --extra-cflags="-w" --enable-debug --target-list="arm-softmmu" && make && make install
 
 # Install demos
 RUN git clone https://github.com/beckus/stm32_p103_demos.git && cd stm32_p103_demos && make
-
-


### PR DESCRIPTION
I changed the fedora version to 28 from docker-hub and added "make" to the installs. These steps were required so that the `docker build` command worked.

Fedora does no longer ship with python 2.7 so this is one issue. Why make was not available I'm not sure. 